### PR TITLE
chore: release version 3.0.0 to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdks",
-  "version": "0.0.0",
+  "version": "3.0.0",
   "dependencies": {
     "@babel/runtime": "7.18.9",
     "@manypkg/cli": "^0.19.2",

--- a/sdks/router-sdk/package.json
+++ b/sdks/router-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@juiceswapxyz/router-sdk",
   "description": "An sdk for routing swaps using JuiceSwap v2 and JuiceSwap v3.",
-  "version": "0.1.5-beta.0",
+  "version": "3.0.0",
   "repository": "https://github.com/JuiceSwapxyz/sdk.git",
   "keywords": [
     "juiceswap",
@@ -22,10 +22,10 @@
   },
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
-    "@juiceswapxyz/sdk-core": "0.1.11-beta.0",
-    "@juiceswapxyz/v2-sdk": "0.1.3-beta.0",
-    "@juiceswapxyz/v3-sdk": "0.1.4-beta.0",
-    "@juiceswapxyz/v4-sdk": "0.1.4-beta.0",
+    "@juiceswapxyz/sdk-core": "3.0.0",
+    "@juiceswapxyz/v2-sdk": "3.0.0",
+    "@juiceswapxyz/v3-sdk": "3.0.0",
+    "@juiceswapxyz/v4-sdk": "3.0.0",
     "@uniswap/swap-router-contracts": "^1.3.0"
   },
   "devDependencies": {
@@ -70,5 +70,5 @@
       ]
     ]
   },
-  "stableVersion": "0.1.2-beta.0"
+  "stableVersion": "3.0.0"
 }

--- a/sdks/sdk-core/package.json
+++ b/sdks/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juiceswapxyz/sdk-core",
-  "version": "0.1.13-beta.0",
+  "version": "3.0.0",
   "description": "⚒️ An SDK for building applications on top of JuiceSwap V3",
   "repository": "https://github.com/JuiceSwapxyz/sdk.git",
   "keywords": [

--- a/sdks/uniswapx-sdk/integration/package.json
+++ b/sdks/uniswapx-sdk/integration/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@ethersproject/bytes": "^5.7.0",
-    "@juiceswapxyz/sdk-core": "0.0.1-beta.0",
+    "@juiceswapxyz/sdk-core": "3.0.0",
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.2",
     "dotenv": "^16.0.3",

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juiceswapxyz/uniswapx-sdk",
-  "version": "0.1.3-beta.0",
+  "version": "3.0.0",
   "repository": "https://github.com/JuiceSwapxyz/sdk.git",
   "keywords": [
     "juiceswap",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
-    "@juiceswapxyz/sdk-core": "0.1.11-beta.0",
+    "@juiceswapxyz/sdk-core": "3.0.0",
     "@uniswap/permit2-sdk": "^1.2.1",
     "ethers": "^5.7.0"
   },
@@ -107,5 +107,5 @@
     }
   },
   "sideEffects": false,
-  "stableVersion": "0.1.0-beta.0"
+  "stableVersion": "3.0.0"
 }

--- a/sdks/universal-router-sdk/package.json
+++ b/sdks/universal-router-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@juiceswapxyz/universal-router-sdk",
   "description": "sdk for integrating with the Universal Router contracts",
-  "version": "0.1.6-beta.0",
+  "version": "3.0.0",
   "repository": "https://github.com/JuiceSwapxyz/sdk.git",
   "keywords": [
     "juiceswap",
@@ -30,11 +30,11 @@
     "test:hardhat": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' hardhat test"
   },
   "dependencies": {
-    "@juiceswapxyz/router-sdk": "0.1.5-beta.0",
-    "@juiceswapxyz/sdk-core": "0.1.11-beta.0",
-    "@juiceswapxyz/v2-sdk": "0.1.3-beta.0",
-    "@juiceswapxyz/v3-sdk": "0.1.4-beta.0",
-    "@juiceswapxyz/v4-sdk": "0.1.4-beta.0",
+    "@juiceswapxyz/router-sdk": "3.0.0",
+    "@juiceswapxyz/sdk-core": "3.0.0",
+    "@juiceswapxyz/v2-sdk": "3.0.0",
+    "@juiceswapxyz/v3-sdk": "3.0.0",
+    "@juiceswapxyz/v4-sdk": "3.0.0",
     "@openzeppelin/contracts": "4.7.0",
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/universal-router": "2.0.0-beta.2",
@@ -101,5 +101,5 @@
     "hoistingLimits": "workspaces"
   },
   "sideEffects": false,
-  "stableVersion": "0.1.2-beta.0"
+  "stableVersion": "3.0.0"
 }

--- a/sdks/v2-sdk/package.json
+++ b/sdks/v2-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@juiceswapxyz/v2-sdk",
   "description": "🛠 An SDK for building applications on top of JuiceSwap V2",
-  "version": "0.1.3-beta.0",
+  "version": "3.0.0",
   "repository": "https://github.com/JuiceSwapxyz/sdk.git",
   "keywords": [
     "juiceswap",
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ethersproject/address": "^5.0.2",
     "@ethersproject/solidity": "^5.0.9",
-    "@juiceswapxyz/sdk-core": "0.1.11-beta.0",
+    "@juiceswapxyz/sdk-core": "3.0.0",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },
@@ -83,5 +83,5 @@
       ]
     ]
   },
-  "stableVersion": "0.1.0-beta.0"
+  "stableVersion": "3.0.0"
 }

--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juiceswapxyz/v3-sdk",
-  "version": "0.1.4-beta.0",
+  "version": "3.0.0",
   "description": "⚒️ An SDK for building applications on top of JuiceSwap V3",
   "repository": "https://github.com/JuiceSwapxyz/sdk.git",
   "keywords": [
@@ -28,7 +28,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/solidity": "^5.0.9",
-    "@juiceswapxyz/sdk-core": "0.1.11-beta.0",
+    "@juiceswapxyz/sdk-core": "3.0.0",
     "@uniswap/swap-router-contracts": "^1.3.0",
     "@uniswap/v3-periphery": "^1.1.1",
     "@uniswap/v3-staker": "1.0.0",
@@ -86,5 +86,5 @@
       ]
     ]
   },
-  "stableVersion": "0.1.1-beta.0"
+  "stableVersion": "3.0.0"
 }

--- a/sdks/v4-sdk/package.json
+++ b/sdks/v4-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@juiceswapxyz/v4-sdk",
   "description": "⚒️ An SDK for building applications on top of JuiceSwap V4",
-  "version": "0.1.4-beta.0",
+  "version": "3.0.0",
   "repository": "https://github.com/JuiceSwapxyz/sdk.git",
   "keywords": [
     "juiceswap",
@@ -27,8 +27,8 @@
   "sideEffects": false,
   "dependencies": {
     "@ethersproject/solidity": "^5.0.9",
-    "@juiceswapxyz/sdk-core": "0.1.11-beta.0",
-    "@juiceswapxyz/v3-sdk": "0.1.4-beta.0",
+    "@juiceswapxyz/sdk-core": "3.0.0",
+    "@juiceswapxyz/v3-sdk": "3.0.0",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },
@@ -95,5 +95,5 @@
       ]
     ]
   },
-  "stableVersion": "0.1.1-beta.0"
+  "stableVersion": "3.0.0"
 }


### PR DESCRIPTION
## Summary
- Release all SDK packages version 3.0.0 to npm
- Packages: sdk-core, v2-sdk, v3-sdk, v4-sdk, router-sdk, universal-router-sdk, uniswapx-sdk

## Citrea Mainnet Release