### PR TITLE
fix: update sdk-core version in uniswapx-sdk integration

### DIFF
--- a/sdks/uniswapx-sdk/integration/package.json
+++ b/sdks/uniswapx-sdk/integration/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@ethersproject/bytes": "^5.7.0",
-    "@juiceswapxyz/sdk-core": "3.0.0",
+    "@juiceswapxyz/sdk-core": "^3.0.2",
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.2",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
## Summary
- Updates `@juiceswapxyz/sdk-core` version in `uniswapx-sdk/integration` from `3.0.0` to `^3.0.2`

## Problem
The integration package had a pinned version (`3.0.0`) while the current published sdk-core version is `3.0.2`. This could cause version mismatches when running integration tests.

## Solution
Changed from pinned `3.0.0` to `^3.0.2` to:
1. Align with the latest published version
2. Allow automatic patch updates
3. Maintain consistency with other packages in the monorepo

## Test plan
- [ ] Verify `yarn install` completes successfully
- [ ] Verify integration tests still pass