### PR TITLE
feat: add Citrea Mainnet V3 contract addresses

### DIFF
--- a/sdks/sdk-core/package.json
+++ b/sdks/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juiceswapxyz/sdk-core",
-  "version": "3.0.0",
+  "version": "3.0.3",
   "description": "⚒️ An SDK for building applications on top of JuiceSwap V3",
   "repository": "https://github.com/JuiceSwapxyz/sdk.git",
   "keywords": [

--- a/sdks/v3-sdk/package.json
+++ b/sdks/v3-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juiceswapxyz/v3-sdk",
-  "version": "3.0.0",
+  "version": "3.0.4",
   "description": "⚒️ An SDK for building applications on top of JuiceSwap V3",
   "repository": "https://github.com/JuiceSwapxyz/sdk.git",
   "keywords": [
@@ -28,7 +28,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/solidity": "^5.0.9",
-    "@juiceswapxyz/sdk-core": "3.0.0",
+    "@juiceswapxyz/sdk-core": "3.0.3",
     "@uniswap/swap-router-contracts": "^1.3.0",
     "@uniswap/v3-periphery": "^1.1.1",
     "@uniswap/v3-staker": "1.0.0",

--- a/sdks/v3-sdk/src/constants.ts
+++ b/sdks/v3-sdk/src/constants.ts
@@ -12,6 +12,7 @@ export function poolInitCodeHash(chainId?: ChainId): string {
     case ChainId.ZKSYNC:
       return '0x010013f177ea1fcbc4520f9a3ca7cd2d1d77959e05aa66484027cb38e712aeed'
     case ChainId.CITREA_TESTNET:
+    case ChainId.CITREA_MAINNET:
       return '0x851d77a45b8b9a205fb9f44cb829cceba85282714d2603d601840640628a3da7'
     default:
       return POOL_INIT_CODE_HASH


### PR DESCRIPTION
## Summary
- Add V3 contract addresses for Citrea Mainnet (chainId 4114) in sdk-core
- Add `POOL_INIT_CODE_HASH` for Citrea Mainnet in v3-sdk constants
- Bump sdk-core to 3.0.3 and v3-sdk to 3.0.4

## Citrea Mainnet V3 Contracts
| Contract | Address |
|----------|---------|
| v3CoreFactoryAddress | `0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82` |
| nonfungiblePositionManagerAddress | `0x3D3821D358f56395d4053954f98aec0E1F0fa568` |
| quoterAddress | `0x428f20dd8926Eabe19653815Ed0BE7D6c36f8425` |
| swapRouter02Address | `0x565eD3D57fe40f78A46f348C220121AE093c3cF8` |
| POOL_INIT_CODE_HASH | `0x851d77a45b8b9a205fb9f44cb829cceba85282714d2603d601840640628a3da7` |

## Test plan
- [x] Packages published to npm successfully
- [ ] Verify V3 position creation works on Citrea Mainnet